### PR TITLE
修复了补考成绩被识别为NaN的问题

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -43,12 +43,16 @@ function getTermGrade(termCode) {
                         else{
                             var reg1 = /[\u65e0\u6548]/; //无效
                             var reg2 = /[\u91cd\u4fee]/; //重修
+                            var reg4 = /[\u8865\u8003]/; //补考
                             if (reg1.test(content)){
                                 classData["credit"] = 0;
                                 classData["name"] = classData["name"] + "(无效)"
                                 content = 0;
                             }
                             else if (reg2.test(content)){
+                                content = content.replace(/[^0-9]/ig,"");;
+                            }
+                            else if (reg4.test(content)){
                                 content = content.replace(/[^0-9]/ig,"");;
                             }
                         }


### PR DESCRIPTION
学长您好，我在使用该插件时发现了这个问题，无法识别标注了“补考”的成绩，现已修改